### PR TITLE
feat: Add support for multiline button labels

### DIFF
--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -704,7 +704,7 @@ def update_button_text_font_size(ui, font_size: int) -> None:
         selected_button.setIcon(icon)
 
 
-def queue_update_button_text(ui, text: str) -> None:
+def queue_update_button_text(ui) -> None:
     """Instead of directly updating the text (label) associated with
     the button, add a small delay. If this is called before the
     timer fires, delay it again. Effectively this creates an update
@@ -713,9 +713,9 @@ def queue_update_button_text(ui, text: str) -> None:
 
     :param ui: Reference to the ui
     :type ui: _type_
-    :param text: The new text value
-    :type text: str
     """
+    text = ui.text.toPlainText()
+
     global text_update_timer
 
     if text_update_timer:

--- a/streamdeck_ui/main.ui
+++ b/streamdeck_ui/main.ui
@@ -292,48 +292,50 @@
              <item row="1" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_3">
                <item>
-                <widget class="QLineEdit" name="text"/>
+                <widget class="QTextEdit" name="text"/>
                </item>
-               <item>
-                <widget class="QPushButton" name="text_v_align">
-                 <property name="minimumSize">
-                  <size>
-                   <width>30</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>30</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="toolTip">
-                  <string>Text vertical alignment</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="resources.qrc">
-                   <normaloff>:/icons/icons/vertical-align.png</normaloff>:/icons/icons/vertical-align.png</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="text_h_align">
-                 <property name="toolTip">
-                  <string>Text horizontal alignment</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="resources.qrc">
-                   <normaloff>:/icons/icons/horizontal-align.png</normaloff>:/icons/icons/horizontal-align.png</iconset>
-                 </property>
-                </widget>
-               </item>
+               <layout class="QVBoxLayout" name="verticalLayout_4">
+                <item>
+                  <widget class="QPushButton" name="text_v_align">
+                  <property name="minimumSize">
+                    <size>
+                    <width>30</width>
+                    <height>0</height>
+                    </size>
+                  </property>
+                  <property name="maximumSize">
+                    <size>
+                    <width>30</width>
+                    <height>16777215</height>
+                    </size>
+                  </property>
+                  <property name="toolTip">
+                    <string>Text vertical alignment</string>
+                  </property>
+                  <property name="text">
+                    <string/>
+                  </property>
+                  <property name="icon">
+                    <iconset resource="resources.qrc">
+                    <normaloff>:/icons/icons/vertical-align.png</normaloff>:/icons/icons/vertical-align.png</iconset>
+                  </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QPushButton" name="text_h_align">
+                  <property name="toolTip">
+                    <string>Text horizontal alignment</string>
+                  </property>
+                  <property name="text">
+                    <string/>
+                  </property>
+                  <property name="icon">
+                    <iconset resource="resources.qrc">
+                    <normaloff>:/icons/icons/horizontal-align.png</normaloff>:/icons/icons/horizontal-align.png</iconset>
+                  </property>
+                  </widget>
+                </item>
+               </layout>
               </layout>
              </item>
              <item row="2" column="0">

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -18,7 +18,7 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QTransform)
 from PySide6.QtWidgets import (QApplication, QComboBox, QFormLayout, QGridLayout,
     QGroupBox, QHBoxLayout, QLabel, QLayout,
-    QLineEdit, QMainWindow, QMenu, QMenuBar,
+    QLineEdit, QTextEdit, QMainWindow, QMenu, QMenuBar,
     QPlainTextEdit, QProgressBar, QPushButton, QSizePolicy,
     QSpinBox, QStatusBar, QTabWidget, QVBoxLayout,
     QWidget)
@@ -210,11 +210,16 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.text = QLineEdit(self.groupBox)
+        self.text = QTextEdit(self.groupBox)
         self.text.setObjectName(u"text")
 
         self.horizontalLayout_3.addWidget(self.text)
 
+        self.verticalLayout_4 = QVBoxLayout()
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+
+        self.horizontalLayout_3.addLayout(self.verticalLayout_4)
+        
         self.text_v_align = QPushButton(self.groupBox)
         self.text_v_align.setObjectName(u"text_v_align")
         self.text_v_align.setMinimumSize(QSize(30, 0))
@@ -223,7 +228,7 @@ class Ui_MainWindow(object):
         icon2.addFile(u":/icons/icons/vertical-align.png", QSize(), QIcon.Normal, QIcon.Off)
         self.text_v_align.setIcon(icon2)
 
-        self.horizontalLayout_3.addWidget(self.text_v_align)
+        self.verticalLayout_4.addWidget(self.text_v_align)
 
         self.text_h_align = QPushButton(self.groupBox)
         self.text_h_align.setObjectName(u"text_h_align")
@@ -231,7 +236,7 @@ class Ui_MainWindow(object):
         icon3.addFile(u":/icons/icons/horizontal-align.png", QSize(), QIcon.Normal, QIcon.Off)
         self.text_h_align.setIcon(icon3)
 
-        self.horizontalLayout_3.addWidget(self.text_h_align)
+        self.verticalLayout_4.addWidget(self.text_h_align)
 
 
         self.formLayout.setLayout(1, QFormLayout.FieldRole, self.horizontalLayout_3)


### PR DESCRIPTION
Adds support for multiline button labels
* Uses QTextEdit in place of QLineEdit
* Add multiline support when calculating horizontal and vertical alignments
* Move horizontal and vertical alignment buttons to vertical layout to mesh better next to larger text widget

![image](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/assets/28697382/6af1e8fb-1ba5-43dc-8a0f-a68fff7d7407)
