### PR TITLE
Make project lint consistent and update to 120 characters per line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]
-line-length = 100
+line-length = 120
 
 [tool.isort]
 profile = "hug"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,20 +2,16 @@
 set -euo pipefail
 
 # if arg --fix is passed, fix the code
-enable_fix=0
 black_flag="--check --diff"
 isort_flag="--check --diff"
 if [[ $# -eq 1 ]] && [[ $1 == "--fix" ]]; then
-    enable_fix=1
     black_flag=""
     isort_flag=""
 fi
 
-
-
 poetry run mypy --ignore-missing-imports streamdeck_ui/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py'
-poetry run isort $isort_flag streamdeck_ui/ tests/ --skip ui_main.py --skip resources_rc.py --skip ui_settings.py --line-length 200
-poetry run black $black_flag streamdeck_ui/ tests/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py' --line-length 200
+poetry run isort $isort_flag streamdeck_ui/ tests/ --skip ui_main.py --skip resources_rc.py --skip ui_settings.py --line-length 120
+poetry run black $black_flag streamdeck_ui/ tests/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py' --line-length 120
 poetry run flake8 streamdeck_ui/ tests/ --ignore F403,F401,W503 --exclude ui_main.py,resources_rc.py,ui_settings.py
 poetry run safety check -i 39462 -i 40291 -i 44715 -i 47794 -i 51457
 poetry run bandit -r streamdeck_ui/

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -11,7 +11,15 @@ from PySide6.QtGui import QImage, QPixmap
 from StreamDeck.Devices import StreamDeck
 from StreamDeck.Transport.Transport import TransportError
 
-from streamdeck_ui.config import CONFIG_FILE_VERSION, DEFAULT_BACKGROUND_COLOR, DEFAULT_FONT, DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE, FONTS_PATH, STATE_FILE
+from streamdeck_ui.config import (
+    CONFIG_FILE_VERSION,
+    DEFAULT_BACKGROUND_COLOR,
+    DEFAULT_FONT,
+    DEFAULT_FONT_COLOR,
+    DEFAULT_FONT_SIZE,
+    FONTS_PATH,
+    STATE_FILE,
+)
 from streamdeck_ui.dimmer import Dimmer
 from streamdeck_ui.display.background_color_filter import BackgroundColorFilter
 from streamdeck_ui.display.display_grid import DisplayGrid
@@ -154,11 +162,18 @@ class StreamDeckServer:
             config = json.loads(state_file.read())
             file_version = config.get("streamdeck_ui_version", 0)
             if file_version != CONFIG_FILE_VERSION:
-                raise ValueError("Incompatible version of config file found: " f"{file_version} does not match required version " f"{CONFIG_FILE_VERSION}.")
+                raise ValueError(
+                    "Incompatible version of config file found: "
+                    f"{file_version} does not match required version "
+                    f"{CONFIG_FILE_VERSION}."
+                )
 
             self.state = {}
             for deck_id, deck in config["state"].items():
-                deck["buttons"] = {int(page_id): {int(button_id): button for button_id, button in buttons.items()} for page_id, buttons in deck.get("buttons", {}).items()}
+                deck["buttons"] = {
+                    int(page_id): {int(button_id): button for button_id, button in buttons.items()}
+                    for page_id, buttons in deck.get("buttons", {}).items()
+                }
                 self.state[deck_id] = deck
 
     def import_config(self, config_file: str) -> None:
@@ -326,7 +341,9 @@ class StreamDeckServer:
     def swap_buttons(self, deck_id: str, page: int, source_button: int, target_button: int) -> None:
         """Swaps the properties of the source and target buttons"""
         temp = cast(dict, self.state[deck_id]["buttons"])[page][source_button]
-        cast(dict, self.state[deck_id]["buttons"])[page][source_button] = cast(dict, self.state[deck_id]["buttons"])[page][target_button]
+        cast(dict, self.state[deck_id]["buttons"])[page][source_button] = cast(dict, self.state[deck_id]["buttons"])[
+            page
+        ][target_button]
         cast(dict, self.state[deck_id]["buttons"])[page][target_button] = temp
         self._save_state()
 
@@ -626,7 +643,9 @@ class StreamDeckServer:
 
             pages = list(deck_state["buttons"].keys())  # type: ignore
 
-            display_handler = self.display_handlers.get(serial_number, DisplayGrid(self.lock, deck, pages, self.cpu_usage_callback))
+            display_handler = self.display_handlers.get(
+                serial_number, DisplayGrid(self.lock, deck, pages, self.cpu_usage_callback)
+            )
             display_handler.set_page(self.get_page(deck_id))
             self.display_handlers[serial_number] = display_handler
 

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -98,22 +98,63 @@ def execute():
         "--action",
         type="string",
         dest="action",
-        help="the action to be performed. valid options (case-insensitive): " + "SET_PAGE, SET_BRIGHTNESS, SET_TEXT, SET_ALIGNMENT, SET_CMD, SET_KEYS, SET_WRITE, SET_ICON, CLEAR_ICON",
+        help="the action to be performed. valid options (case-insensitive): "
+        + "SET_PAGE, SET_BRIGHTNESS, SET_TEXT, SET_ALIGNMENT, SET_CMD, SET_KEYS, SET_WRITE, SET_ICON, CLEAR_ICON",
         metavar="NAME",
     )
 
-    parser.add_option("-d", "--deck", type="int", dest="deck_index", help="the deck to be manipulated. defaults to the currently selected deck in the ui", metavar="INDEX")
-    parser.add_option("-p", "--page", type="int", dest="page_index", help="the page to be manipulated. defaults to the currently active page", metavar="INDEX")
-    parser.add_option("-b", "--button", type="int", dest="button_index", help="the button to be manipulated", metavar="INDEX")
-
-    parser.add_option("--icon", type="string", dest="icon_path", help="path to an icon. used with SET_ICON", metavar="PATH")
-    parser.add_option("--brightness", type="int", dest="brightness", help="brightness to set, 0-100. used with SET_BRIGHTNESS", metavar="VALUE")
-    parser.add_option("--text", type="string", dest="button_text", help="button text to set. used with SET_TEXT", metavar="VALUE")
-    parser.add_option("--write", type="string", dest="button_write", help="text to be written when the button is pressed. used with SET_WRITE", metavar="VALUE")
-    parser.add_option("--command", type="string", dest="button_cmd", help="button command to set. used with SET_CMD", metavar="VALUE")
-    parser.add_option("--keys", type="string", dest="button_keys", help="button keys to set. used with SET_KEYS", metavar="VALUE")
     parser.add_option(
-        "--alignment", type="string", dest="button_text_alignment", help="button text alignment. used with SET_ALIGNMENT. valid values: top, middle-top, middle, middle-bottom, bottom", metavar="VALUE"
+        "-d",
+        "--deck",
+        type="int",
+        dest="deck_index",
+        help="the deck to be manipulated. defaults to the currently selected deck in the ui",
+        metavar="INDEX",
+    )
+    parser.add_option(
+        "-p",
+        "--page",
+        type="int",
+        dest="page_index",
+        help="the page to be manipulated. defaults to the currently active page",
+        metavar="INDEX",
+    )
+    parser.add_option(
+        "-b", "--button", type="int", dest="button_index", help="the button to be manipulated", metavar="INDEX"
+    )
+
+    parser.add_option(
+        "--icon", type="string", dest="icon_path", help="path to an icon. used with SET_ICON", metavar="PATH"
+    )
+    parser.add_option(
+        "--brightness",
+        type="int",
+        dest="brightness",
+        help="brightness to set, 0-100. used with SET_BRIGHTNESS",
+        metavar="VALUE",
+    )
+    parser.add_option(
+        "--text", type="string", dest="button_text", help="button text to set. used with SET_TEXT", metavar="VALUE"
+    )
+    parser.add_option(
+        "--write",
+        type="string",
+        dest="button_write",
+        help="text to be written when the button is pressed. used with SET_WRITE",
+        metavar="VALUE",
+    )
+    parser.add_option(
+        "--command", type="string", dest="button_cmd", help="button command to set. used with SET_CMD", metavar="VALUE"
+    )
+    parser.add_option(
+        "--keys", type="string", dest="button_keys", help="button keys to set. used with SET_KEYS", metavar="VALUE"
+    )
+    parser.add_option(
+        "--alignment",
+        type="string",
+        dest="button_text_alignment",
+        help="button text alignment. used with SET_ALIGNMENT. valid values: top, middle-top, middle, middle-bottom, bottom",
+        metavar="VALUE",
     )
 
     (options, args) = parser.parse_args(sys.argv)
@@ -143,7 +184,13 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_text", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "text": options.button_text}
+            data = {
+                "command": "set_text",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "text": options.button_text,
+            }
         elif action_name == "set_write":
             if options.button_write is None:
                 print("error: --write not set...")
@@ -151,7 +198,13 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_write", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "write": options.button_write}
+            data = {
+                "command": "set_write",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "write": options.button_write,
+            }
         elif action_name == "set_alignment":
             if options.button_text_alignment is None:
                 print("error: --alignment not set...")
@@ -159,7 +212,13 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_alignment", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "alignment": options.button_text_alignment}
+            data = {
+                "command": "set_alignment",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "alignment": options.button_text_alignment,
+            }
         elif action_name == "set_cmd":
             if options.button_cmd is None:
                 print("error: --command not set...")
@@ -167,7 +226,13 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_cmd", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_cmd": options.button_cmd}
+            data = {
+                "command": "set_cmd",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "button_cmd": options.button_cmd,
+            }
         elif action_name == "set_keys":
             if options.button_keys is None:
                 print("error: --keys not set...")
@@ -175,7 +240,13 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_keys", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_keys": options.button_keys}
+            data = {
+                "command": "set_keys",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "button_keys": options.button_keys,
+            }
         elif action_name == "set_icon":
             if options.icon_path is None:
                 print("error: --icon not set...")
@@ -183,12 +254,23 @@ def execute():
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "set_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "icon": options.icon_path}
+            data = {
+                "command": "set_icon",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+                "icon": options.icon_path,
+            }
         elif action_name == "clear_icon":
             if options.button_index is None:
                 print("error: --button not set...")
                 return
-            data = {"command": "clear_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index}
+            data = {
+                "command": "clear_icon",
+                "deck": options.deck_index,
+                "page": options.page_index,
+                "button": options.button_index,
+            }
 
     if data is not None:
         write_json(sock, data)

--- a/streamdeck_ui/dimmer.py
+++ b/streamdeck_ui/dimmer.py
@@ -5,7 +5,9 @@ from StreamDeck.Transport.Transport import TransportError
 
 
 class Dimmer:
-    def __init__(self, timeout: int, brightness: int, brightness_dimmed: int, brightness_callback: Callable[[int], None]):
+    def __init__(
+        self, timeout: int, brightness: int, brightness_dimmed: int, brightness_callback: Callable[[int], None]
+    ):
         """Constructs a new Dimmer instance
 
         :param int timeout: The time in seconds before the dimmer starts.

--- a/streamdeck_ui/display/background_color_filter.py
+++ b/streamdeck_ui/display/background_color_filter.py
@@ -19,7 +19,13 @@ class BackgroundColorFilter(Filter):
         self.image = Image.new("RGB", size)
         self.image.paste(self.color, (0, 0, size[0], size[1]))
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Optional[Image.Image], int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Optional[Image.Image], int]:
         if not input_changed:
             return None, self.hashcode
         return self.image, self.hashcode

--- a/streamdeck_ui/display/display_grid.py
+++ b/streamdeck_ui/display/display_grid.py
@@ -25,7 +25,14 @@ class DisplayGrid:
 
     lock: threading.Lock
 
-    def __init__(self, lock: threading.Lock, streamdeck: StreamDeck, pages: List[int], cpu_callback: Callable[[str, int], None], fps: int = 25):
+    def __init__(
+        self,
+        lock: threading.Lock,
+        streamdeck: StreamDeck,
+        pages: List[int],
+        cpu_callback: Callable[[str, int], None],
+        fps: int = 25,
+    ):
         """Creates a new display instance
 
         :param lock: A lock object that will be used to get exclusive access while enumerating

--- a/streamdeck_ui/display/empty_filter.py
+++ b/streamdeck_ui/display/empty_filter.py
@@ -25,7 +25,13 @@ class EmptyFilter(filter.Filter):
     def initialize(self, size: Tuple[int, int]):
         self.image = Image.new("RGB", size)
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         """
         Returns an empty Image object.
 

--- a/streamdeck_ui/display/filter.py
+++ b/streamdeck_ui/display/filter.py
@@ -34,7 +34,13 @@ class Filter(ABC):
         pass
 
     @abstractmethod
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         """
         Transforms the given input image to the desired output image.
         The default behaviour is to return the orignal image.

--- a/streamdeck_ui/display/image_filter.py
+++ b/streamdeck_ui/display/image_filter.py
@@ -76,7 +76,13 @@ class ImageFilter(Filter):
         self.current_frame = next(self.frame_cycle)
         self.frame_time = Fraction()
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         """
         The transformation returns the loaded image, ando overwrites whatever came before.
         """

--- a/streamdeck_ui/display/keypress_filter.py
+++ b/streamdeck_ui/display/keypress_filter.py
@@ -29,7 +29,13 @@ class KeypressFilter(Filter):
         self.size = size
         pass
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         frame_hash = hash((self.filter_hash, self.active))
         if input_changed or self.active != self.last_state:
             self.last_state = self.active

--- a/streamdeck_ui/display/pulse_filter.py
+++ b/streamdeck_ui/display/pulse_filter.py
@@ -24,7 +24,13 @@ class PulseFilter(Filter):
     def initialize(self, size: Tuple[int, int]):
         pass
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         brightness_changed = False
         if time - self.last_time > self.pulse_delay:
             brightness_changed = True

--- a/streamdeck_ui/display/text_filter.py
+++ b/streamdeck_ui/display/text_filter.py
@@ -12,7 +12,9 @@ class TextFilter(Filter):
 
     image: Image
 
-    def __init__(self, text: str, font: str, font_size: int, font_color: str, vertical_align: str, horizontal_align: str):
+    def __init__(
+        self, text: str, font: str, font_size: int, font_color: str, vertical_align: str, horizontal_align: str
+    ):
         super(TextFilter, self).__init__()
         self.text = text
         self.vertical_align = vertical_align
@@ -50,7 +52,9 @@ class TextFilter(Filter):
         # font placement and should allow for button text to horizontally align
         # across buttons. Basically we want to figure out what is the tallest
         # text we will need to draw.
-        _, _, _, label_h = foreground_draw.textbbox((0, 0), "\n".join(["lLpgyL|"] * len(text_split_newline)), font=self.true_font)
+        _, _, _, label_h = foreground_draw.textbbox(
+            (0, 0), "\n".join(["lLpgyL|"] * len(text_split_newline)), font=self.true_font
+        )
 
         gap = (size[1] - 5 * label_h) // 4
 
@@ -77,9 +81,24 @@ class TextFilter(Filter):
 
         label_pos = (label_x, label_y)
 
-        foreground_draw.multiline_text(label_pos, text=self.text, font=self.true_font, fill=self.font_color, align=self.horizontal_align, spacing=0, stroke_fill="black", stroke_width=2)
+        foreground_draw.multiline_text(
+            label_pos,
+            text=self.text,
+            font=self.true_font,
+            fill=self.font_color,
+            align=self.horizontal_align,
+            spacing=0,
+            stroke_fill="black",
+            stroke_width=2,
+        )
 
-    def transform(self, get_input: Callable[[], Image.Image], get_output: Callable[[int], Image.Image], input_changed: bool, time: Fraction) -> Tuple[Image.Image, int]:
+    def transform(
+        self,
+        get_input: Callable[[], Image.Image],
+        get_output: Callable[[int], Image.Image],
+        input_changed: bool,
+        time: Fraction,
+    ) -> Tuple[Image.Image, int]:
         """
         The transformation returns the loaded image, ando overwrites whatever came before.
         """

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -11,11 +11,28 @@ import pkg_resources
 from PySide6 import QtWidgets
 from PySide6.QtCore import QMimeData, QSettings, QSignalBlocker, QSize, Qt, QTimer, QUrl
 from PySide6.QtGui import QAction, QDesktopServices, QDrag, QIcon, QPalette
-from PySide6.QtWidgets import QApplication, QColorDialog, QDialog, QFileDialog, QMainWindow, QMenu, QMessageBox, QSizePolicy, QSystemTrayIcon
+from PySide6.QtWidgets import (
+    QApplication,
+    QColorDialog,
+    QDialog,
+    QFileDialog,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QSizePolicy,
+    QSystemTrayIcon,
+)
 
 from streamdeck_ui.api import StreamDeckServer
 from streamdeck_ui.cli.server import CLIStreamDeckServer
-from streamdeck_ui.config import APP_LOGO, APP_NAME, DEFAULT_BACKGROUND_COLOR, DEFAULT_FONT_COLOR, FONTS_PATH, STATE_FILE
+from streamdeck_ui.config import (
+    APP_LOGO,
+    APP_NAME,
+    DEFAULT_BACKGROUND_COLOR,
+    DEFAULT_FONT_COLOR,
+    FONTS_PATH,
+    STATE_FILE,
+)
 from streamdeck_ui.modules.keyboard import Keyboard, pynput_supported
 from streamdeck_ui.semaphore import Semaphore, SemaphoreAcquireError
 from streamdeck_ui.ui_main import Ui_MainWindow
@@ -350,7 +367,9 @@ def select_image(window) -> None:
             image_file = os.path.expanduser("~")
         else:
             image_file = last_image_dir
-    file_name = QFileDialog.getOpenFileName(window, "Open Image", image_file, "Image Files (*.png *.jpg *.bmp *.svg *.gif)")[0]
+    file_name = QFileDialog.getOpenFileName(
+        window, "Open Image", image_file, "Image Files (*.png *.jpg *.bmp *.svg *.gif)"
+    )[0]
     if file_name:
         last_image_dir = os.path.dirname(file_name)
         deck_id = _deck_id(window.ui)
@@ -581,7 +600,9 @@ def build_buttons(ui, tab) -> None:
 
 
 def export_config(window) -> None:
-    file_name = QFileDialog.getSaveFileName(window, "Export Config", os.path.expanduser("~/streamdeck_ui_export.json"), "JSON (*.json)")[0]
+    file_name = QFileDialog.getSaveFileName(
+        window, "Export Config", os.path.expanduser("~/streamdeck_ui_export.json"), "JSON (*.json)"
+    )[0]
     if not file_name:
         return
 
@@ -589,7 +610,9 @@ def export_config(window) -> None:
 
 
 def import_config(window) -> None:
-    file_name = QFileDialog.getOpenFileName(window, "Import Config", os.path.expanduser("~"), "Config Files (*.json)")[0]
+    file_name = QFileDialog.getOpenFileName(window, "Import Config", os.path.expanduser("~"), "Config Files (*.json)")[
+        0
+    ]
     if not file_name:
         return
 


### PR DESCRIPTION
## Motivation

The project uses [black](https://pypi.org/project/black/) and [isort](https://pypi.org/project/isort/) to ensure the correct format of the files but if you look at the pyproject.toml you'll notice that black was configure there with 100 line length but the scripts/lint.sh which is used in the pipeline the line lenght is set to 200 making really hard to use autoformat tools in the IDE/text editor

I consider 100 very little and 200 a lot, I set in this PR the line length consistently to 120

## Description of the changes
- Make consistent the line length in pyproject.toml and scripts/lint.sh to 120 characters
- Format source files using `./scripts/lint.sh`


## Notes
 - I checked [isort documentation](https://pycqa.github.io/isort/docs/configuration/config_files.html#isortcfg-preferred-format)  and it looks like the pyproject.toml doesnt include line lenght setting there