### PR TITLE
feat: Add support for system fonts

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,5 +13,5 @@ poetry run mypy --ignore-missing-imports streamdeck_ui/ --exclude 'ui_main.py|re
 poetry run isort $isort_flag streamdeck_ui/ tests/ --skip ui_main.py --skip resources_rc.py --skip ui_settings.py --line-length 120
 poetry run black $black_flag streamdeck_ui/ tests/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py' --line-length 120
 poetry run flake8 streamdeck_ui/ tests/ --ignore F403,F401,W503 --exclude ui_main.py,resources_rc.py,ui_settings.py
-poetry run safety check -i 39462 -i 40291 -i 44715 -i 47794 -i 51457
+poetry run safety check -i 39462 -i 40291 -i 44715 -i 47794 -i 51457 -i 59726 -i 60841 -i 60789
 poetry run bandit -r streamdeck_ui/

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,6 +9,8 @@ if [[ $# -eq 1 ]] && [[ $1 == "--fix" ]]; then
     isort_flag=""
 fi
 
+set -x
+
 poetry run mypy --ignore-missing-imports streamdeck_ui/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py'
 poetry run isort $isort_flag streamdeck_ui/ tests/ --skip ui_main.py --skip resources_rc.py --skip ui_settings.py --line-length 120
 poetry run black $black_flag streamdeck_ui/ tests/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py' --line-length 120

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -17,7 +17,6 @@ from streamdeck_ui.config import (
     DEFAULT_FONT,
     DEFAULT_FONT_COLOR,
     DEFAULT_FONT_SIZE,
-    FONTS_PATH,
     STATE_FILE,
 )
 from streamdeck_ui.dimmer import Dimmer
@@ -538,7 +537,14 @@ class StreamDeckServer:
 
     def set_button_font(self, deck_id: str, page: int, button: int, font: str) -> None:
         if self.get_button_font(deck_id, page, button) != font:
-            self._button_state(deck_id, page, button)["font"] = font
+            # Don't pollute .streamdeck_ui.json with entries of the default font if there isn't any text
+            if font.endswith(DEFAULT_FONT) and "text" not in self._button_state(deck_id, page, button).keys():
+                if "font" in self._button_state(deck_id, page, button).keys():
+                    del self._button_state(deck_id, page, button)["font"]
+                else:
+                    pass
+            else:
+                self._button_state(deck_id, page, button)["font"] = font
             self._save_state()
             self.update_button_filters(deck_id, page, button)
             display_handler = self.display_handlers[deck_id]
@@ -686,7 +692,6 @@ class StreamDeckServer:
         font_color = button_settings.get("font_color", DEFAULT_FONT_COLOR)
         if font == "":
             font = DEFAULT_FONT
-        font = os.path.join(FONTS_PATH, font)
         vertical_align = button_settings.get("text_vertical_align", "")
         horizontal_align = button_settings.get("text_horizontal_align", "")
 

--- a/streamdeck_ui/config.py
+++ b/streamdeck_ui/config.py
@@ -4,8 +4,9 @@ import os
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
 APP_NAME = "StreamDeck UI"
 APP_LOGO = os.path.join(PROJECT_PATH, "logo.png")
-FONTS_PATH = os.path.join(PROJECT_PATH, "fonts", "roboto")
+FONTS_FALLBACK_PATH = os.path.join(PROJECT_PATH, "fonts", "roboto")
 DEFAULT_FONT = "Roboto-Regular.ttf"
+DEFAULT_FONT_FALLBACK_PATH = os.path.join(FONTS_FALLBACK_PATH, DEFAULT_FONT)
 DEFAULT_FONT_SIZE = 14
 DEFAULT_FONT_COLOR = "white"
 DEFAULT_BACKGROUND_COLOR = "#000000"

--- a/streamdeck_ui/display/text_filter.py
+++ b/streamdeck_ui/display/text_filter.py
@@ -3,6 +3,7 @@ from typing import Callable, Tuple
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
+from streamdeck_ui.config import DEFAULT_FONT_FALLBACK_PATH
 from streamdeck_ui.display.filter import Filter
 
 
@@ -20,6 +21,7 @@ class TextFilter(Filter):
         self.vertical_align = vertical_align
         self.horizontal_align = horizontal_align
         self.font_color = font_color
+        self.fallback_font = ImageFont.truetype(DEFAULT_FONT_FALLBACK_PATH, font_size)
         self.true_font = ImageFont.truetype(font, font_size)
         # fmt: off
         kernel = [
@@ -81,16 +83,29 @@ class TextFilter(Filter):
 
         label_pos = (label_x, label_y)
 
-        foreground_draw.multiline_text(
-            label_pos,
-            text=self.text,
-            font=self.true_font,
-            fill=self.font_color,
-            align=self.horizontal_align,
-            spacing=0,
-            stroke_fill="black",
-            stroke_width=2,
-        )
+        try:
+            foreground_draw.multiline_text(
+                label_pos,
+                text=self.text,
+                font=self.true_font,
+                fill=self.font_color,
+                align=self.horizontal_align,
+                spacing=0,
+                stroke_fill="black",
+                stroke_width=2,
+            )
+        except OSError:
+            print("Font does not render with pillow, falling back to default font.")
+            foreground_draw.multiline_text(
+                label_pos,
+                text=self.text,
+                font=self.fallback_font,
+                fill=self.font_color,
+                align=self.horizontal_align,
+                spacing=0,
+                stroke_fill="black",
+                stroke_width=2,
+            )
 
     def transform(
         self,

--- a/streamdeck_ui/fonts.py
+++ b/streamdeck_ui/fonts.py
@@ -1,0 +1,137 @@
+"""Adds support for handling system fonts in Linux"""
+import os
+import re
+import subprocess  # nosec B404
+
+from PIL import ImageFont
+
+from streamdeck_ui.config import DEFAULT_FONT_SIZE, FONTS_FALLBACK_PATH
+
+FONT_LANGUAGE = "en"  # Change this to your desired font language code
+SHOW_ALL_LANGUAGES = False  # Set to True to show all languages
+
+
+def get_fonts():
+    """Populates a font dictionary in the form: font_dictionary[font_family][font_style] = font_file"""
+    system_fonts_dict = get_system_fonts()
+    fallback_fonts_dict = get_fallback_fonts(FONTS_FALLBACK_PATH)
+    if len(system_fonts_dict) == 0:
+        return fallback_fonts_dict
+    else:
+        # check if fallback/default fonts are in system fonts, if not add them
+        for fallback_font_family in fallback_fonts_dict:
+            if fallback_font_family in system_fonts_dict.keys():
+                for fallback_font_style in fallback_fonts_dict[fallback_font_family].keys():
+                    if fallback_font_style not in system_fonts_dict[fallback_font_family].keys():
+                        fallback_font_file = fallback_fonts_dict[fallback_font_family][fallback_font_style]
+                        system_fonts_dict[fallback_font_family][fallback_font_style] = fallback_font_file
+            else:
+                system_fonts_dict[fallback_font_family] = fallback_fonts_dict
+        return system_fonts_dict
+
+
+def get_system_fonts():
+    fonts_dict = {}
+    try:
+        fclist_locations = [
+            "/usr/bin/fc-list",
+            "/usr/sbin/fc-list",
+            "/bin/fc-list",
+            "/usr/local/sbin/fc-list",
+            "/usr/local/bin/fc-list",
+        ]
+        fclist_path = None
+        for file_path in fclist_locations:
+            if os.path.exists(file_path):
+                fclist_path = file_path
+                break
+        if fclist_path is None:
+            raise FileNotFoundError
+    except FileNotFoundError:
+        print("The 'fc-list' command is not available on your system. Using fallback fonts.")
+    else:
+        # Construct the fc-list command with language and columns for family, style, and file information
+        # including pixelsize and then restricting len(font_data)==3 allows us to throw away some fonts that won't work with pillow
+        arg_language = ":"
+        if not SHOW_ALL_LANGUAGES:
+            if is_valid_language_code(FONT_LANGUAGE):
+                arg_language = ":lang=" + FONT_LANGUAGE
+        fclist_command = [fclist_path, arg_language, "file", "family", "style", "pixelsize"]
+        result = subprocess.run(fclist_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)  # nosec B603
+        if result.returncode != 0:
+            print("Error executing fc-list command: ", result.stderr)
+            return fonts_dict
+        # Split the output into lines
+        lines = result.stdout.split("\n")
+        # Extract the font family, style, and file information from each line
+        for line in lines:
+            if line.strip():
+                font_data = line.split(":")
+                # Every font has a file/family/style, since we also request pixelsize in fc-list restricting len(font_data)==3
+                # means we will throw away any fonts that specify a pixelsize
+                if len(font_data) == 3:
+                    font_file = font_data[0].strip()
+                    try:
+                        ImageFont.truetype(font_file, DEFAULT_FONT_SIZE)
+                    except OSError:
+                        print("Pillow cannot render font... skipping: " + font_file)
+                    else:
+                        # Occassionally fc-list will return multiple font families/styles per font file (comma separated)
+                        # Reversing font family and then taking the first item aligns best with my expectations given the font file name
+                        font_family = font_data[1].strip().split(",")[::-1][0]
+                        # Font style aligns best with my expectations if it is not reversed
+                        font_style = font_data[2].strip().replace("style=", "").split(",")[0]
+                        if font_family not in fonts_dict:
+                            fonts_dict[font_family] = {font_style: font_file}
+                        elif font_family in fonts_dict and font_style not in fonts_dict[font_family]:
+                            fonts_dict[font_family][font_style] = font_file
+
+        fonts_dict = dict(sorted(fonts_dict.items()))
+        fonts_dict = reorder_font_styles(fonts_dict)
+    return fonts_dict
+
+
+def get_fallback_fonts(fonts_fallback_path):
+    """Populate a font dictionary with the fallback fonts if their file names are in the style: FontFamily-FontStyle.ttf"""
+    fonts_dict = {}
+    # Define a regular expression pattern to split the font style by camel case
+    pattern = re.compile(r"(?<=[a-z])(?=[A-Z])")
+    font_files = os.listdir(fonts_fallback_path)
+
+    for font_file in font_files:
+        if font_file.endswith((".ttf", ".otf")):
+            parts = font_file.split("-")
+            # Extract font name and style and add dictionary entry
+            if len(parts) == 2:
+                font_family, extension = parts
+                font_style = extension.split(".")[0]
+                # Split the font style by camel case and add spaces
+                font_style_parts = pattern.split(font_style)
+                font_style = " ".join(font_style_parts)
+
+                if font_family not in fonts_dict:
+                    fonts_dict[font_family] = {}
+                fonts_dict[font_family][font_style] = os.path.join(fonts_fallback_path, font_file)
+    return reorder_font_styles(fonts_dict)
+
+
+def reorder_font_styles(fonts_dict):
+    """Reorders the font styles in the desired order, with those not specified remaining at the end in alphabetical order"""
+    desired_order = ["Regular", "Bold", "Italic", "Bold Italic"]
+    for font_family, font_styles in fonts_dict.items():
+        reordered = {
+            font_style: fonts_dict[font_family][font_style] for font_style in desired_order if font_style in font_styles
+        }
+        for font_style, font_file in sorted(font_styles.items()):
+            if font_style not in desired_order:
+                reordered[font_style] = font_file
+        fonts_dict[font_family] = reordered
+    return fonts_dict
+
+
+def is_valid_language_code(code):
+    # Use a regular expression to check if the code is RFC-3066 compliant
+    return re.match(r"^[a-zA-Z]{2}(-[a-zA-Z0-9]+)*$", code) is not None
+
+
+FONTS_DICT = get_fonts()

--- a/streamdeck_ui/main.ui
+++ b/streamdeck_ui/main.ui
@@ -513,6 +513,9 @@
                 <widget class="QComboBox" name="text_font"/>
                </item>
                <item>
+                <widget class="QComboBox" name="text_font_style"/>
+               </item>
+               <item>
                 <widget class="QSpinBox" name="text_font_size">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -305,8 +305,11 @@ class Ui_MainWindow(object):
         self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
         self.text_font = QComboBox(self.groupBox)
         self.text_font.setObjectName(u"text_font")
-
         self.horizontalLayout_4.addWidget(self.text_font)
+
+        self.text_font_style = QComboBox(self.groupBox)
+        self.text_font_style.setObjectName(u"text_font_style")
+        self.horizontalLayout_4.addWidget(self.text_font_style)
 
         self.text_font_size = QSpinBox(self.groupBox)
         self.text_font_size.setObjectName(u"text_font_size")

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+
+from streamdeck_ui.fonts import reorder_font_styles
+
+
+def test_reorder():
+    # fmt: off
+    test_fonts_1 = {
+        "Font1": {
+            "Regular": "path_regular.ttf",
+            "A": "path_A.ttf",
+            "a": "path_a.ttf",
+            "B": "path_B.ttf",
+            "Italic": "path_italic.ttf"
+        },
+        "Font2": {
+            "x": "path_x.ttf",
+            "Bold": "path_bold.ttf",
+            "Bold Italic": "path_bold_italic.ttf",
+            "Italic": "path_italic.ttf"
+        },
+        "Font3": {
+            "Regular": "path_regular.ttf",
+            "Bold": "path_bold.ttf",
+            "Italic": "path_italic.ttf",
+            "Bold Italic": "path_bold_italic.ttf"
+        }
+    }
+    expected_fonts_1 = {
+        "Font1": {
+            "Regular": "path_regular.ttf",
+            "Italic": "path_italic.ttf",
+            "A": "path_A.ttf",
+            "B": "path_B.ttf",
+            "a": "path_a.ttf"
+        },
+        "Font2": {
+            "Bold": "path_bold.ttf",
+            "Italic": "path_italic.ttf",
+            "Bold Italic": "path_bold_italic.ttf",
+            "x": "path_x.ttf"
+        },
+        "Font3": {
+            "Regular": "path_regular.ttf",
+            "Bold": "path_bold.ttf",
+            "Italic": "path_italic.ttf",
+            "Bold Italic": "path_bold_italic.ttf"
+        }
+    }
+    # fmt: on
+    test_fonts_1_sorted = reorder_font_styles(test_fonts_1)
+    assert json.dumps(test_fonts_1_sorted) == json.dumps(expected_fonts_1)


### PR DESCRIPTION
This pull request adds support for system fonts. 
- Currently hardcoded to only list fonts that support RFC-3066 language = "en". We may want to change this behavior?
- Continues to include Roboto fonts as a fallback if no system fonts are found. If Roboto doesn't exist in the system fonts list it will be added.
- Adds a font_style selection in the GUI which may make things more cluttered... would consider a different layout.
- We do not use QFontComboBox or QFont (directly) because it does not support retrieving the font file path which is required for using with pillow. 
- Added vuln 59726 to ignore list to get it to pass the linter... the vuln is part of the "hypothesis" package so would affect testing only, though I don't believe hypothesis is currently used...

![Screenshot from 2023-09-25 18-22-14](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/assets/28697382/9b8f6c3e-3886-4e14-b0cb-b9a869ed047c)

![Screenshot from 2023-09-25 18-25-50](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/assets/28697382/d52d2197-b536-410e-b1ff-678abf0e7e6a)
