### PR TITLE
feat: Add support for default config

### DIFF
--- a/streamdeck_ui/config.py
+++ b/streamdeck_ui/config.py
@@ -16,6 +16,7 @@ DEFAULT_FONT_SIZE = 14
 DEFAULT_FONT_COLOR = "#ffffff"
 DEFAULT_BACKGROUND_COLOR = "#000000"
 STATE_FILE = os.environ.get("STREAMDECK_UI_CONFIG", os.path.expanduser("~/.streamdeck_ui.json"))
+LOG_FILE = os.environ.get("STREAMDECK_UI_LOG_FILE", os.path.expanduser("~/.streamdeck_ui.log"))
 STATE_FILE_BACKUP = os.path.expanduser("~/.streamdeck_ui.json_old")
 CONFIG_FILE_VERSION = 2
 CONFIG_FILE_PREVIOUS_VERSION = 1

--- a/streamdeck_ui/logger.py
+++ b/streamdeck_ui/logger.py
@@ -1,0 +1,11 @@
+import logging
+import sys
+
+from streamdeck_ui.config import LOG_FILE
+
+logger = logging.getLogger("streamdeck_ui")
+stderr_handler = logging.StreamHandler(sys.stderr)
+file_handler = logging.FileHandler(LOG_FILE)
+logger.addHandler(stderr_handler)
+logger.addHandler(file_handler)
+logger.setLevel(logging.INFO)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.common import STREAMDECK_SERIAL, TestableStreamDeckServer, create_test_api_server
+from tests.common import STREAMDECK_SERIAL, STREAMDECK_TYPE, TestableStreamDeckServer, create_test_api_server
 
 
 @pytest.fixture(autouse=True)
@@ -31,3 +31,8 @@ def api_server() -> TestableStreamDeckServer:
 @pytest.fixture
 def streamdeck_serial() -> str:
     return STREAMDECK_SERIAL
+
+
+@pytest.fixture
+def streamdeck_type():
+    return STREAMDECK_TYPE

--- a/tests/api/test_default_state.py
+++ b/tests/api/test_default_state.py
@@ -1,0 +1,17 @@
+from copy import deepcopy
+
+
+def test_set_default_state__no_change(api_server, streamdeck_type, streamdeck_serial):
+    default_state = deepcopy(api_server.state)
+    api_server.set_default_state(streamdeck_serial, streamdeck_type)
+    assert api_server.state == default_state
+
+
+def test_set_default_state__set_type_config(api_server, streamdeck_type, streamdeck_serial):
+    new_serial = "UNKNOWN_SERIAL"
+    default_state = deepcopy(api_server.state)
+    api_server.set_default_state(new_serial, streamdeck_type)
+    assert new_serial != streamdeck_serial
+    assert api_server.state != default_state
+    assert api_server.state[new_serial] != api_server.state[streamdeck_serial]
+    assert api_server.state[new_serial] == api_server.state[streamdeck_type]

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,6 +5,7 @@ from streamdeck_ui.model import ButtonMultiState, ButtonState, DeckState
 
 STREAMDECK_SERIAL = "DL4XXXXXX"
 STREAMDECK_KEY_COUNT = 3
+STREAMDECK_TYPE = "Stream Deck Original"
 
 # the number of pages in the test state
 PAGES = 3
@@ -45,12 +46,19 @@ def create_test_api_server() -> TestableStreamDeckServer:
     api.dimmers[STREAMDECK_SERIAL] = MagicMock()
 
     api.state = {
+        STREAMDECK_TYPE: DeckState(
+            buttons={
+                0: func_gen_page(),
+                1: func_gen_page(),
+                2: func_gen_page(),
+            },
+        ),
         STREAMDECK_SERIAL: DeckState(
             buttons={
                 0: func_gen_page(),
                 1: func_gen_page(),
             },
-        )
+        ),
     }
     # we don't want to save the state to disk
     api._save_state = MagicMock()


### PR DESCRIPTION
Hello, :wave: 
This is a proposal for the problem discussed here:  https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/discussions/35.
Which raise multiple different but linked issue:  initial configuration, cloning configuration, sharing configuration.

This proposal give only a "default" configuration.
The idea is able to have some kind of default configuration for any new connected streamdeck.
At first connection, it gets a default configuration. If you save the configuration, the specific streamdeck will have a configuration for itself.

The current implementation is only usable by modifying manually the configuration file, but is still a great workaround for many usages. We can expect a support Gui with buttons like:

- "set as default config" 
-  "set as default Stream Deck Origin config 
-  "restore to default"
-  "restore to Stream Deck original default config"

in another pull request.

I try to propose something simple, as this may raise many different ideas.

The current implementation proposes this kind of configuration file, which is not so great, but don’t force us to modify the format of the configuration file:

```javascript
{
    "streamdeck_ui_version": 1,
    "state": {
        "default": {
            // … default streamdeck config of any streamdeck
        },
        "Stream Deck Original": {
            // … streamdeck config for any original streamdeck
        },
        "OPI232389379823": {
            // … specific streamdeck config for a specific streamdeck.
        }
    }
}
```

Thanks for yours feedback :smile: 
