### PR TITLE
fix(timers.py): ensure to disconnect previous debouced calls

### DIFF
--- a/streamdeck_ui/modules/utils/timers.py
+++ b/streamdeck_ui/modules/utils/timers.py
@@ -14,12 +14,19 @@ def debounce(timeout=500):
         timer.setSingleShot(True)
 
         def partial_func(*args, **kwargs):
-            timer.timeout.disconnect()
+            try:
+                timer.timeout.disconnect()
+            except BaseException:
+                pass
             return func(*args, **kwargs)
 
         def wrapped(*args, **kwargs):
             if timer.isActive():
                 timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except BaseException:
+                pass
             timer.timeout.connect(partial(partial_func, *args, **kwargs))
             timer.start(timeout)
 


### PR DESCRIPTION
debounce was not disconnecting correctly previous calls ending by call previous partial_func when timeout.
this results in bad behavior when you type in any debouced field

