### PR TITLE
fix #21 Ensure palette frames are RGBA

### DIFF
--- a/streamdeck_ui/display/image_filter.py
+++ b/streamdeck_ui/display/image_filter.py
@@ -69,6 +69,11 @@ class ImageFilter(Filter):
         self.frames = []
         for frame, milliseconds, hashcode in zip(frames, frame_duration, frame_hash):
             frame = frame.copy()
+            if frame.mode == "P":
+                try:
+                    frame = frame.convert("RGBA")
+                except BaseException:
+                    pass
             frame.thumbnail(size, Image.LANCZOS)
             self.frames.append((frame, milliseconds, hashcode))
 


### PR DESCRIPTION
# Description of the changes

if P mode is detected converted try to convert to RGBA. GIF are not transparent by nature, but there's a modern technique that allow to encode transparency in a palette in the first frame. the application was not recognising that frame as RGBA resulting in a glitch (white flash)

Fix the #21

# Demo

https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/assets/395707/d7a39ca6-1bd8-488a-9139-b5a17f3d5cc2