### PR TITLE
fix: ensure correctly initialization of pipeline when new page is added

### DIFF
--- a/streamdeck_ui/display/display_grid.py
+++ b/streamdeck_ui/display/display_grid.py
@@ -79,10 +79,10 @@ class DisplayGrid:
         DisplayGrid._empty_filter.initialize(self.size)
 
     def initialize_page(self, page: int):
-        with self.lock:
-            self.pages[page] = {}
-            for button in range(self.streamdeck.key_count()):
-                self.pages[page][button] = Pipeline()
+        self.pages[page] = {}
+        for button in range(self.streamdeck.key_count()):
+            self.pages[page][button] = Pipeline()
+            self.replace(page, button, [])
 
     def remove_page(self, page: int):
         with self.lock:


### PR DESCRIPTION
each button contains a pipeline that need to be initialized correctly, that was not correctly initialized when a new page was added resulting in weird behavior where the icons of the previous page are visualized when the button in the selected page does not have any property set