### PR TITLE
fix: switch page/button state race condition

### DIFF
--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -185,6 +185,12 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
 
         page = api.get_page(deck_id)
         command = api.get_button_command(deck_id, page, key)
+        keys = api.get_button_keys(deck_id, page, key)
+        write = api.get_button_write(deck_id, page, key)
+        brightness_change = api.get_button_change_brightness(deck_id, page, key)
+        switch_page = api.get_button_switch_page(deck_id, page, key)
+        switch_state = api.get_button_switch_state(deck_id, page, key)
+
         if command:
             try:
                 Popen(shlex.split(command))  # nosec, need to allow execution of arbitrary commands
@@ -194,7 +200,6 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
 
         keyboard = Keyboard()
 
-        keys = api.get_button_keys(deck_id, page, key)
         if keys:
             try:
                 keyboard.keys(keys)
@@ -202,7 +207,6 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
                 print(f"Could not press keys '{keys}': {error}")
                 show_tray_warning_message("Unable to perform key press action.")
 
-        write = api.get_button_write(deck_id, page, key)
         if write:
             try:
                 keyboard.write(write)
@@ -210,7 +214,6 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
                 print(f"Could not complete the write command: {error}")
                 show_tray_warning_message("Unable to perform write action.")
 
-        brightness_change = api.get_button_change_brightness(deck_id, page, key)
         if brightness_change:
             try:
                 api.change_brightness(deck_id, brightness_change)
@@ -218,7 +221,6 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
                 print(f"Could not change brightness: {error}")
                 show_tray_warning_message("Unable to change brightness.")
 
-        switch_page = api.get_button_switch_page(deck_id, page, key)
         if switch_page:
             switch_page_index = switch_page - 1
             if switch_page_index in api.get_pages(deck_id):
@@ -233,7 +235,6 @@ def handle_keypress(ui, deck_id: str, key: int, state: bool) -> None:
                     f"Unable to perform switch page, the page {switch_page} does not exist in your current settings"
                 )
 
-        switch_state = api.get_button_switch_state(deck_id, page, key)
         if switch_state:
             switch_state_index = switch_state - 1
             if switch_state_index in api.get_button_states(deck_id, page, key):


### PR DESCRIPTION
when a button include actions like switch page or switch button may happen that the destination include a switch and results in calling the two switch when only one should be called

fixed by pull all the data first then do the switches

if you want to confirm this bug before actually merging this

- in the development
- in some page (example: page 1) to some button (button 10) set switch page (set to switch to page 2)
- in the page 2 to the button 10, add at last two states and make the state 1 switch to state 2 and state2  switch to state 1
- ensure each state has a different color or label so you will notice
- go to page 1 and hit the button 10, the page will switch but also the button will change its state

The correct behavior is: when hit button 10 in page 1 should switch to page 2, nothing more