### PR TITLE
fix: allow button image to update with same selected file path

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -11,6 +11,7 @@ if [[ $# -eq 1 ]] && [[ $1 == "--fix" ]]; then
     isort_flag=""
 fi
 
+set -x
 
 poetry run mypy --ignore-missing-imports streamdeck_ui/ --exclude 'ui_main.py|resources_rc.py|ui_settings.py|ui_button.py'
 poetry run isort $isort_flag streamdeck_ui/ tests/ --skip ui_main.py --skip resources_rc.py --skip ui_settings.py  --skip ui_button.py --line-length 120

--- a/streamdeck_ui/display/image_filter.py
+++ b/streamdeck_ui/display/image_filter.py
@@ -24,10 +24,16 @@ class ImageFilter(Filter):
     def __init__(self, file: str):
         super(ImageFilter, self).__init__()
         self.file = os.path.expanduser(file)
+        file_stats = os.stat(file)
+        file_size = file_stats.st_size
+        mod_time = file_stats.st_mtime
+
+        # Create a tuple of the file metadata for creating a hashcode.
+        self.metadata = (self.__class__, self.file, file_size, mod_time)
 
     def initialize(self, size: Tuple[int, int]):
-        # Each frame needs to have a unique hashcode. Start with file name as baseline.
-        image_hash = hash((self.__class__, self.file))
+        # Each frame needs to have a unique hashcode.
+        image_hash = hash(self.metadata)
         frame_duration = []
         frame_hash = []
 

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -738,6 +738,11 @@ def show_button_state_image_dialog() -> None:
     )[0]
 
     if file_name:
+        if file_name == image_file:
+            # if the user selects the same file name, clear out the last image
+            # this will allow the image to update in the case where the user edited the image
+            # and saved over the original file
+            update_displayed_button_attribute("icon", "")
         last_image_dir = os.path.dirname(file_name)
         update_displayed_button_attribute("icon", file_name)
 


### PR DESCRIPTION
This PR addresses issue #126. Pillow is bumped to pass safety check (everything appears to be working still...). Added set -x to lint.sh to make it easier to follow which command generated which output.