### PR TITLE
Key image size bug fixes

### DIFF
--- a/streamdeck_ui/display/display_grid.py
+++ b/streamdeck_ui/display/display_grid.py
@@ -20,9 +20,6 @@ class DisplayGrid:
     filters for one individual button display.
     """
 
-    _empty_filter: EmptyFilter = EmptyFilter()
-    "Static instance of EmptyFilter shared by all pipelines"
-
     lock: threading.Lock
 
     def __init__(
@@ -58,6 +55,11 @@ class DisplayGrid:
             # Default to original stream deck size - even though we're not actually going to display anything
         self.serial_number = streamdeck.get_serial_number()
 
+        self._empty_filter: EmptyFilter = EmptyFilter()
+        self._empty_filter.initialize(self.size)
+        # Instance of EmptyFilter shared by all pipelines related to this
+        # DisplayGrid instance
+
         self.pages: Dict[int, Dict[int, Pipeline]] = {}
         # A dictionary of lists of pipelines. Each page has
         # a list, corresponding to each button.
@@ -76,7 +78,7 @@ class DisplayGrid:
         for page in pages:
             self.initialize_page(page)
         # The sync event allows a caller to wait until all the buttons have been processed
-        DisplayGrid._empty_filter.initialize(self.size)
+
 
     def initialize_page(self, page: int):
         self.pages[page] = {}
@@ -91,7 +93,7 @@ class DisplayGrid:
     def replace(self, page: int, button: int, filters: List[Filter]):
         with self.lock:
             pipeline = Pipeline()
-            pipeline.add(DisplayGrid._empty_filter)
+            pipeline.add(self._empty_filter)
             for pipeline_filter in filters:
                 pipeline_filter.initialize(self.size)
                 pipeline.add(pipeline_filter)

--- a/streamdeck_ui/display/image_filter.py
+++ b/streamdeck_ui/display/image_filter.py
@@ -86,7 +86,8 @@ class ImageFilter(Filter):
                     frame = frame.convert("RGBA")
                 except BaseException:
                     pass
-            frame.thumbnail(size, Image.LANCZOS)
+            scale_factor = min(size[0] / frame.size[0], size[1] / frame.size[1])
+            frame = frame.resize((int(v * scale_factor) for v in frame.size), Image.LANCZOS)
             self.frames.append((frame, milliseconds, hashcode))
 
         self.frame_cycle = itertools.cycle(self.frames)


### PR DESCRIPTION
- The change to streamdeck_ui/display/image_filter.py scales images up as well as down. PIL's Image.thumbnail method can never return an image larger than the original image, which makes images smaller than the key size such as desktop icons - e.g. with a lower resolution like 32x32 or 48x48 - not fill up the entire key image space. Image.resize lets any icon fill up the key.

- The change to streamdeck_ui/display/display_grid.py is more subtle:

    If you have more than one Stream Deck connected and they have different key image sizes - for example a Stream Deck XL with 96x96 keys and a Stream Deck Plus with 120x120 keys - two DisplayGrid instances are created. The first one initialize the static class-level EmptyFilter instance upon creation and sets its image size once. Then the second one is created and sets the same EmptyFilter's image size a second time. Meaning all key images changed subsequently will have the key size of the last Stream Deck initialized.

    So in this example, if the Stream Deck Plus is the last one initialized, any key image changed on the Stream Deck XL will be 120x120, then scaled down to 96x96 upon display, appearing too small.

    The issue is fixed by having one EmptyFilter instance per DisplayGrid instance, each with the correct key size for the corresponding Stream Deck.