### PR TITLE
fix: resolve inability to select buttons in the ui

### DIFF
--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -936,7 +936,9 @@ def build_buttons(ui, tab) -> None:
     #  and all the other buttons
     for button in buttons:
         button.clicked.connect(
-            lambda current_button=button, all_buttons=buttons: button_clicked(current_button, all_buttons)
+            lambda checked=False, current_button=button, all_buttons=buttons: button_clicked(
+                current_button, all_buttons
+            )
         )
 
 


### PR DESCRIPTION
The first argument passed to the `clicked` callback returns whether the item is `checked` or not.

This should resolve the issue reported in #197 and #200.