### PR TITLE
Remove semaphore file once app terminates

### DIFF
--- a/streamdeck_ui/semaphore.py
+++ b/streamdeck_ui/semaphore.py
@@ -28,6 +28,9 @@ class Semaphore:
         # release the semaphore
         fcntl.flock(self.semaphore_fd, fcntl.LOCK_UN)
 
+        # remove semaphore file
+        os.remove(self.semaphore_file)
+        
         # close the file descriptor
         os.close(self.semaphore_fd)
 


### PR DESCRIPTION
First pull request ever, please have patience with me. From the original project there was a bug about leaving the semaphore lock file in the /tmp folder once the app terminates.

I believe this should fix that from happening by requesting the lock-file to be removed upon termination of the Semaphore instance.