### PR TITLE
fix: streamdeck service starts to early 

### DIFF
--- a/scripts/streamdeck.service
+++ b/scripts/streamdeck.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=A Linux compatible UI for the Elgato Stream Deck.
+After=graphical-session.target
+Requires=graphical-session.target
 
 [Service]
 Type=simple
@@ -7,4 +9,4 @@ ExecStart=<path to streamdeck> -n
 Restart=on-failure
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
streamdeck service starts to early making xdg-desktop-portal-* services fail on Fedora 39 (gnome 45) and Fedora 40.

```
$ systemctl --user status xdg-desktop-portal-gtk
xdg-desktop-portal-gtk.service - Portal service (GTK/GNOME implementation)
     Loaded: loaded (/usr/lib/systemd/user/xdg-desktop-portal-gtk.service; static)
    Drop-In: /usr/lib/systemd/user/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead)

mai 17 08:51:35 elmo systemd[3584]: Failed to start xdg-desktop-portal-gtk.service - Portal service (GTK/GNOME implementation).
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Start request repeated too quickly.
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Failed with result 'exit-code'.
mai 17 08:51:35 elmo systemd[3584]: Failed to start xdg-desktop-portal-gtk.service - Portal service (GTK/GNOME implementation).
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Start request repeated too quickly.
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Failed with result 'exit-code'.
mai 17 08:51:35 elmo systemd[3584]: Failed to start xdg-desktop-portal-gtk.service - Portal service (GTK/GNOME implementation).
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Start request repeated too quickly.
mai 17 08:51:35 elmo systemd[3584]: xdg-desktop-portal-gtk.service: Failed with result 'exit-code'.
mai 17 08:51:35 elmo systemd[3584]: Failed to start xdg-desktop-portal-gtk.service - Portal service (GTK/GNOME implementation).
```

```
$ systemctl --user status xdg-desktop-portal-gnome
○ xdg-desktop-portal-gnome.service - Portal service (GNOME implementation)
     Loaded: loaded (/usr/lib/systemd/user/xdg-desktop-portal-gnome.service; static)
    Drop-In: /usr/lib/systemd/user/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead)
● streamdeck.service - A Linux compatible UI for the Elgato Stream Deck.
     Loaded: loaded (/home/jshedde/.local/share/systemd/user/streamdeck.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/user/service.d
             └─10-timeout-abort.conf
```

Those services are at least responsible for screensharing so that a bit anoying.