### PR TITLE
 docs(keys): clarify unsupported x11 hex keysyms

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -165,10 +165,10 @@ bash -c "wmctrl -a firefox  && xdotool key alt+1"
 
 Simuliert Tasten-Kombinationen (hot keys). Grundsätzlich werden Tasten, die gleichzeitig betätigt werden, mit einem `+` Zeichen verbunden. Trennen sie Tasten-Kombinationen mit einem `,` , wenn zusätzliche Kombinationen benötigt werden. Die Zeichenfolge `alt+F4,f` zum Beispiel bedeutet drücke und halte `alt`, gefolgt von `F4` und lass dann beide los. Drücke anschließend `f` und lass es wieder los.
 
-Sie können auch einen Tasten-Code im hex Format verwenden, `0x74` ist zum Beispiel der Tasten-Code für `t`. Dieser Wert wird auch manchmal als keysym bezeichnet.
+Verwenden sie Tasten-Namen direkt (zum Beispiel `t`, `capslock` oder `numpad_divide`).
+Hex-Keysyms aus Tools wie `xev` (zum Beispiel `0x74`, `0xffe5`, `0xffaf`) werden vom `evdev` Backend nicht unterstützt.
 
-> Sie können das tool `xev` verwenden um den Key-Code einer Taste zu ermitteln.
-> Suchen sie in der Ausgabe nach **keysym hex value**, zum Beispiel `(keysym 0x74, t)`
+> Sie können das Tool `evtest` verwenden, um das Verhalten einer Taste zu prüfen und auf einen `evdev` Tasten-Namen zuzuordnen.
 >
 > Verwenden sie `comma` oder `plus`, wenn sie ein `,` oder ein `+` *ausgeben* wollen.
 >
@@ -186,11 +186,11 @@ Sie können auch einen Tasten-Code im hex Format verwenden, `0x74` ist zum Beisp
 * `1,delay,delay,2,delay,delay,3` - tippe 123 mit 1-Sekunden Pausen zwischen den Tastendrucken (unter Verwendung der Standardpausen).
 * `1,delay 1,2,delay 1,3` - tippe 123 mit 1-Sekunden Pausen zwischen den Tastendrucken (unter Verwendung selbst definierter Pausen).
 * `e,c,h,o,space,",t,e,s,t,",enter` - tippe `echo "test"` und drücke Enter.
-* `ctrl+alt+0x74` - öffnet ein neues Terminalfenster. `0x74` ist der Tasten-Code von `t`. TIP: Verwenden sie den Tasten-Code, wenn der Buchstabe nicht funktioniert.
-* `0xffe5` - Caps Lock umschalten.
-* `0xffaf` - Die `/` Taste im Ziffernblock der Tastatur.
+* `ctrl+alt+t` - öffnet in vielen Desktop-Umgebungen ein neues Terminalfenster.
+* `capslock` - Caps Lock umschalten.
+* `numpad_divide` - Die `/` Taste im Ziffernblock der Tastatur.
 
-Die Standardliste der Tasten finden sie [im source-code](https://pynput.readthedocs.io/en/latest/_modules/pynput/keyboard/_base.html#Key).
+Die unterstützten Tasten-Namen stammen aus den `evdev` Tasten plus Aliasen in `streamdeck_ui/modules/keyboard.py`.
 
 Die `super` Taste (Windows-Taste) kann bei einigen Linux-Versionen problematisch sein. Statt der Tastendruck-Funktion können sie dann die Befehls-Funktion wie folgt benutzen. In diesem Beispiel wollen wir die `Super` Taste und `4` drücken, was die Anwendung Nummer 4 ihrer Favoriten startet (Ubuntu).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,10 +69,10 @@ bash -c "wmctrl -a firefox  && xdotool key alt+1"
 
 Simulates key press combinations (hot keys). The basic format is a group of keys, separated by a `+` sign to press simultaneously. Separate key combination groups with a `,` if additional key combinations are needed. For example, `alt+F4,f` means press and hold `alt`, followed by `F4` and then release both. Next, press and release `f`.
 
-You can also specify a KeyCode in hex format, for example, `0x74` is the KeyCode for `t`. This is also sometimes called the keysym value.
+Use key names directly (for example, `t`, `capslock`, or `numpad_divide`).
+Hex keysyms from tools like `xev` (for example, `0x74`, `0xffe5`, `0xffaf`) are not supported by the `evdev` backend.
 
-> You can use the `xev` tool and capture the key you are looking for.
-> In the output, look for the **keysym hex value**, for example `(keysym 0x74, t)`
+> You can use the `evtest` tool to inspect key behavior on your system and map it to an `evdev` key name.
 >
 > Use `comma` or `plus` if you want to actually *output* `,` or `+` respectively.
 >
@@ -90,11 +90,11 @@ You can also specify a KeyCode in hex format, for example, `0x74` is the KeyCode
 * `1,delay,delay,2,delay,delay,3` — Type 123 with a 1-second delay between key presses (using default delay).
 * `1,delay 1,2,delay 1,3` — Type 123 with a 1-second delay between key presses (using custom delay).
 * `e,c,h,o,space,",t,e,s,t,",enter` — Type `echo "test"` and press enter.
-* `ctrl+alt+0x74` — Opens a new terminal window. `0x74` is the KeyCode for `t`. TIP: If the character doesn't work, try using the KeyCode instead.
-* `0xffe5` — Toggle Caps Lock.
-* `0xffaf` — The `/` key on the numeric key pad.
+* `ctrl+alt+t` — Opens a new terminal window in many desktop environments.
+* `capslock` — Toggle Caps Lock.
+* `numpad_divide` — The `/` key on the numeric key pad.
 
-The standard list of keys can be found [at the source](https://pynput.readthedocs.io/en/latest/_modules/pynput/keyboard/_base.html#Key).
+The supported key names come from `evdev` key names plus aliases declared in `streamdeck_ui/modules/keyboard.py`.
 
 The `super` key (Windows key) can be problematic on some versions of Linux. Instead of using the Key Press feature, you could use the Command feature as follows. In this example, it will press `Super` and `4`, which launches application number 4 in your favorites (Ubuntu).
 

--- a/tests/modules/test_keyboard.py
+++ b/tests/modules/test_keyboard.py
@@ -18,6 +18,7 @@ from streamdeck_ui.modules.keyboard import _DEFAULT_ADDITIONAL_DELAY, _DELAY_KEY
         ("CTRL++", [[e.KEY_LEFTCTRL]]),
         ("CTRL+numpad_add", [[e.KEY_LEFTCTRL, e.KEY_KPPLUS]]),
         ("CTRL+numpad_0", [[e.KEY_LEFTCTRL, e.KEY_KP0]]),
+        ("numpad_divide", [[e.KEY_KPSLASH]]),
         ("CTRL+0", [[e.KEY_LEFTCTRL, e.KEY_0]]),
         ("CTRL+KP0", [[e.KEY_LEFTCTRL, e.KEY_KP0]]),
         ("CTRL + ", [[e.KEY_LEFTCTRL]]),
@@ -43,3 +44,8 @@ def test_parse_keys_as_keycodes(keys, expected):
 def test_parse_keys_as_keycodes_with_invalid_key():
     with pytest.raises(ValueError):
         parse_keys_as_keycodes("invalid_key")
+
+
+def test_parse_keys_as_keycodes_with_hex_keysym():
+    with pytest.raises(ValueError, match="Invalid keys"):
+        parse_keys_as_keycodes("0xffaf")


### PR DESCRIPTION
# What changes

- replace xev keysym-hex examples with evdev key names in keypress docs
- align keyboard test expectation with the generic `Invalid keys` error for `0xffaf`

When evdev replaced pynput for keypress handling, some docs examples were not updated and became inconsistent with runtime behavior.


Close #201 