### PR TITLE
Align evdev backend references in UI and  docs

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -217,7 +217,7 @@ Joe
 
 Stellen sie sicher, dass sie die neueste Version verwenden mit `pip3 show streamdeck-ui`. Vergleichen sie es mit: [![PyPI version](https://badge.fury.io/py/streamdeck-ui.svg)](http://badge.fury.io/py/streamdeck-ui)
 
-* Streamdeck verwendet [pynput](https://github.com/moses-palmer/pynput) zur Simulation derf **Tasten-Betätigungen** wodurch ordentliche [Unterstützung für Wayland](https://github.com/moses-palmer/pynput/issues/189) fehlt. Im Allgemeinen werden sie gute Ergebnisse bei Verwendung von X haben (Ubuntu/Linux Mint). [Dieser thread](https://github.com/timothycrosley/streamdeck-ui/issues/47) lönnte nützlich sein.
+* Streamdeck verwendet [evdev](https://python-evdev.readthedocs.io/) mit `uinput` zur Simulation von **Tasten-Betätigungen** und **Text schreiben**. Wenn das nicht funktioniert, prüfen sie die `uinput`-Berechtigungen und die udev-Konfiguration aus den Installationsanleitungen.
 * **Taste drücken** oder **Text schreiben** funktioniert nicht unter Fedora (außerhalb von streamdeck selbst), was nicht besonders hilfreich ist. Die **Befehls-Funktion** kann aber trotzdem eine Menge.
 * Version [1.0.2](https://pypi.org/project/streamdeck-ui/) hat keine Fehler-Behandlung bei der **Befehls-** und der **Taste drücken** Funktion. Deshalb müssen sie vorsichtig sein - ein ungültiger Befehl oder Tastendruck stoppt auch alle anderen Prozesse. Bitte upgraden sie zur neuesten Version.
 * Einige Anwender haben berichtet, dass das Stream Deck Gerätnicht an allen USB-ports funktioniert, da es einiges an Strom verbraucht und/oder [strenge Bandbreitenanforderungen](https://github.com/timothycrosley/streamdeck-ui/issues/69#issuecomment-715887397) hat. Versuchen sie einen anderen Anschluß.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you need any help, have a question, or just want to discuss something related
 ## Known issues
 
 * pip package is not yet available for the current state of the project. Please install from source, currently trying to find a better way to provide the package.
-* Streamdeck uses [pynput](https://github.com/moses-palmer/pynput) for simulating **Key Presses** but it lacks proper [support for Wayland](https://github.com/moses-palmer/pynput/issues/189). Generally your results will be good when using X (Ubuntu/Linux Mint). [This thread](https://github.com/timothycrosley/streamdeck-ui/issues/47) may be useful.
+* Streamdeck uses [evdev](https://python-evdev.readthedocs.io/) with `uinput` for simulating **Key Presses** and **Write Text**. If these actions do not work, verify your `uinput` permissions and udev setup from the installation guides.
 * **Key Press** or **Write Text** does not work on Fedora (outside of the streamdeck itself), which is not particularly useful. However, still do a lot with the **Command** feature.
 * Some users have reported that the Stream Deck device does not work on all on specific USB ports, as it draws quite a bit of power and/or has [strict bandwidth requirements](https://github.com/timothycrosley/streamdeck-ui/issues/69#issuecomment-715887397). Try a different port.
 * If you are executing a shell script from the Command feature - remember to add the shebang at the top of your file, for the language in question. `#!/bin/bash` or `#!/usr/bin/python3` etc. The streamdeck may appear to lock up if you don't under some distros.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,8 @@ There are **four** important things you need to get a working system.
 
 ## Key Press and Write Text do not work
 
-  Streamdeck uses [pynput](https://github.com/moses-palmer/pynput) for simulating **Key Presses**, but it was not designed for [Wayland](https://github.com/moses-palmer/pynput/issues/189). Generally your results will be good when using X, but it seems like most new releases of Linux are switching away from it.
+  Streamdeck uses [evdev](https://python-evdev.readthedocs.io/) with `uinput` for simulating **Key Presses** and **Write Text**.
+  If these actions do not work, verify that `/dev/uinput` is available and that your user has the required permissions from the udev setup in the installation guides.
 
 ## ImportError
 

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -1076,7 +1076,7 @@ class MainWindow(QMainWindow):
         description = "A Linux compatible UI for the Elgato Stream Deck."
         app = QApplication.instance()
         body = [description, "Version {}\n".format(app.applicationVersion())]
-        dependencies = ("streamdeck", "pyside6", "pillow", "pynput")
+        dependencies = ("streamdeck", "pyside6", "pillow", "evdev")
         for dep in dependencies:
             try:
                 dist_version = version(dep)


### PR DESCRIPTION
# What changes

- Update relevant documents that are misaligned with the current keyboard strategy
- Update the About dialog dependency list to display `evdev` instead of `pynput`.


Closes #149 